### PR TITLE
Various fixes

### DIFF
--- a/confluenceDumpWithPython.py
+++ b/confluenceDumpWithPython.py
@@ -40,6 +40,8 @@ parser.add_argument('--tags', action='store_true', default=False,
                     help='Add labels as .. tags::', required=False)
 parser.add_argument('--html', action='store_true', default=False,
                     help='Include .html file in export (default is only .rst)', required=False)
+parser.add_argument('--no-rst', action='store_false', dest="rst", default=True,
+                    help='Disable .rst file in export', required=False)
 parser.add_argument('--showlabels', action='store_true', default=False,
                     help='Export .rst files with the page labels at the bottom', required=False)
 
@@ -100,7 +102,7 @@ if args.mode == 'single':
     my_outdirs = myModules.mk_outdirs(my_outdir_base)               # attachments, embeds, scripts
     my_page_labels = myModules.get_page_labels(atlassian_site,page_id,user_name,api_token)
     print(f"Base export folder is \"{my_outdir_base}\" and the Content goes to \"{my_outdir_content}\"")
-    myModules.dump_html(atlassian_site,my_body_export_view_html,my_body_export_view_title,page_id,my_outdir_base, my_outdir_content,my_page_labels,page_parent,user_name,api_token,sphinx_compatible,sphinx_tags,arg_html_output=args.html)
+    myModules.dump_html(atlassian_site,my_body_export_view_html,my_body_export_view_title,page_id,my_outdir_base, my_outdir_content,my_page_labels,page_parent,user_name,api_token,sphinx_compatible,sphinx_tags,arg_html_output=args.html,arg_rst_output=args.rst)
     print("Done!")
 elif args.mode == 'space':
     ###########
@@ -166,7 +168,7 @@ elif args.mode == 'space':
             #my_body_export_view_labels = ",".join(myModules.get_page_labels(atlassian_site,p['page_id'],user_name,api_token))
             mypage_url = f"{my_body_export_view['_links']['base']}{my_body_export_view['_links']['webui']}"
             print(f"dump_html arg sphinx_compatible = {sphinx_compatible}")
-            myModules.dump_html(atlassian_site,my_body_export_view_html,my_body_export_view_title,p['page_id'],my_outdir_base,my_outdir_content,my_body_export_view_labels,p['parentId'],user_name,api_token,sphinx_compatible,sphinx_tags,arg_html_output=args.html)
+            myModules.dump_html(atlassian_site,my_body_export_view_html,my_body_export_view_title,p['page_id'],my_outdir_base,my_outdir_content,my_body_export_view_labels,p['parentId'],user_name,api_token,sphinx_compatible,sphinx_tags,arg_html_output=args.html,arg_rst_output=args.rst)
     print("Done!")
 elif args.mode == 'pageprops':
     ###############
@@ -238,6 +240,7 @@ elif args.mode == 'pageprops':
                 arg_sphinx_tags=sphinx_tags,
                 arg_type="reportchild",
                 arg_html_output=args.html,
+                arg_rst_output=args.rst,
                 arg_show_labels=args.showlabels
             )                  # creates html files for every child
     myModules.dump_html(
@@ -255,6 +258,7 @@ elif args.mode == 'pageprops':
             arg_sphinx_tags=sphinx_tags,
             arg_type="report",
             arg_html_output=args.html,
+            arg_rst_output=args.rst,
             arg_show_labels=args.showlabels
         )         # finally creating the HTML for the report page
     print("Done!")

--- a/confluenceDumpWithPython.py
+++ b/confluenceDumpWithPython.py
@@ -100,7 +100,7 @@ if args.mode == 'single':
     my_outdirs = myModules.mk_outdirs(my_outdir_base)               # attachments, embeds, scripts
     my_page_labels = myModules.get_page_labels(atlassian_site,page_id,user_name,api_token)
     print(f"Base export folder is \"{my_outdir_base}\" and the Content goes to \"{my_outdir_content}\"")
-    myModules.dump_html(atlassian_site,my_body_export_view_html,my_body_export_view_title,page_id,my_outdir_base, my_outdir_content,my_page_labels,page_parent,user_name,api_token,sphinx_compatible,sphinx_tags)
+    myModules.dump_html(atlassian_site,my_body_export_view_html,my_body_export_view_title,page_id,my_outdir_base, my_outdir_content,my_page_labels,page_parent,user_name,api_token,sphinx_compatible,sphinx_tags,arg_html_output=args.html)
     print("Done!")
 elif args.mode == 'space':
     ###########
@@ -166,7 +166,7 @@ elif args.mode == 'space':
             #my_body_export_view_labels = ",".join(myModules.get_page_labels(atlassian_site,p['page_id'],user_name,api_token))
             mypage_url = f"{my_body_export_view['_links']['base']}{my_body_export_view['_links']['webui']}"
             print(f"dump_html arg sphinx_compatible = {sphinx_compatible}")
-            myModules.dump_html(atlassian_site,my_body_export_view_html,my_body_export_view_title,p['page_id'],my_outdir_base,my_outdir_content,my_body_export_view_labels,p['parentId'],user_name,api_token,sphinx_compatible,sphinx_tags)
+            myModules.dump_html(atlassian_site,my_body_export_view_html,my_body_export_view_title,p['page_id'],my_outdir_base,my_outdir_content,my_body_export_view_labels,p['parentId'],user_name,api_token,sphinx_compatible,sphinx_tags,arg_html_output=args.html)
     print("Done!")
 elif args.mode == 'pageprops':
     ###############

--- a/confluenceDumpWithPython.py
+++ b/confluenceDumpWithPython.py
@@ -34,7 +34,7 @@ parser.add_argument('--label', '-l', type=str,
                     help='Page label')
 parser.add_argument('--outdir', '-o', type=str, default='output',
                     help='Folder for export', required=False)
-parser.add_argument('--sphinx', '-x', action='store_true', default=True,
+parser.add_argument('--sphinx', '-x', action='store_true', default=False,
                     help='Sphinx compatible folder structure', required=False)
 parser.add_argument('--tags', action='store_true', default=False,
                     help='Add labels as .. tags::', required=False)

--- a/myModules.py
+++ b/myModules.py
@@ -377,7 +377,7 @@ def dump_html(
     # Putting HTML together
     #
     pretty_html = soup.prettify()
-    html_file = open(html_file_path, 'w')
+    html_file = open(html_file_path, 'w', encoding='utf-8')
     html_file.write(my_header)
     html_file.write(pretty_html)
     if len(my_attachments) > 0:
@@ -422,7 +422,7 @@ def dump_html(
         else:
             footer_rst = ""
 
-        rst_file = open(rst_file_path, 'w')
+        rst_file = open(rst_file_path, 'w', encoding='utf-8')
         rst_file.write(rst_page_header)
         rst_file.write(output_rst)
         rst_file.write(footer_rst)

--- a/myModules.py
+++ b/myModules.py
@@ -1,3 +1,4 @@
+import shutil
 import requests
 import os.path
 import json
@@ -70,7 +71,7 @@ def mk_outdirs(arg_outdir="output"):       # setting default to output
         os.mkdir(outdir_styles)
 
     if not os.path.exists(outdir_styles + '/confluence.css'):
-        os.system('cp ' + script_dir + '/styles/confluence.css "' + outdir_styles + '"')
+        shutil.copy(f"{script_dir}/styles/confluence.css", f"{outdir_styles}confluence.css")
     return(outdir_list)
 
 def get_space_title(arg_site,arg_space_id,arg_username,arg_api_token):

--- a/myModules.py
+++ b/myModules.py
@@ -199,6 +199,7 @@ def dump_html(
     arg_sphinx_tags=False,
     arg_type="",
     arg_html_output=False,
+    arg_rst_output=True,
     arg_show_labels=False
     ):
     """Create HTML and RST files
@@ -406,6 +407,9 @@ def dump_html(
     #
     # convert html to rst
     #
+    if not arg_rst_output:
+        return
+    
     rst_file_name = f"{html_file_name.replace('html','rst')}"
     rst_file_path = os.path.join(my_outdir_content,rst_file_name)
     try:

--- a/myModules.py
+++ b/myModules.py
@@ -279,22 +279,25 @@ def dump_html(
             my_embed_external_path_relative = os.path.join(str('../' + my_vars['attach_dir']),my_embed_external_name)
         else:
             my_embed_external_path_relative = os.path.join(my_vars['attach_dir'],my_embed_external_name)
-        to_download = requests.get(orig_embed_external_path, allow_redirects=True)
         try:
-            open(my_embed_external_path,'wb').write(to_download.content)
+            if not os.path.exists(my_embed_external_path):
+                to_download = requests.get(orig_embed_external_path, allow_redirects=True)
+                open(my_embed_external_path,'wb').write(to_download.content)
+            img = Image.open(my_embed_external_path)
         except:
-            print(orig_embed_external_path)
-        img = Image.open(my_embed_external_path)
-        if img.width < 600:
-            embed_ext['width'] = img.width
+            print(f"WARNING: Skipping embed file {my_embed_external_path} due to issues. url: {orig_embed_external_path}")
         else:
-            embed_ext['width'] = 600
-        img.close
-        embed_ext['height'] = "auto"
-        embed_ext['onclick'] = f"window.open(\"{my_embed_external_path_relative}\")"
-        embed_ext['src'] = str(my_embed_external_path_relative)
-        embed_ext['data-image-src'] = str(my_embed_external_path_relative)
-        my_embeds_externals_counter = my_embeds_externals_counter + 1
+            if img is not None:
+                if img.width < 600:
+                    embed_ext['width'] = img.width
+                else:
+                    embed_ext['width'] = 600
+                img.close
+                embed_ext['height'] = "auto"
+                embed_ext['onclick'] = f"window.open(\"{my_embed_external_path_relative}\")"
+                embed_ext['src'] = str(my_embed_external_path_relative)
+                embed_ext['data-image-src'] = str(my_embed_external_path_relative)
+                my_embeds_externals_counter = my_embeds_externals_counter + 1
 
     #
     # dealing with "confluence-embedded-image"
@@ -315,7 +318,7 @@ def dump_html(
             if not os.path.exists(my_embed_path):
                 to_download = requests.get(orig_embed_path, allow_redirects=True, auth=(arg_username, arg_api_token))
                 open(my_embed_path,'wb').write(to_download.content)
-                img = Image.open(my_embed_path)
+            img = Image.open(my_embed_path)
         except:
             print(f"WARNING: Skipping embed file {my_embed_path} due to issues. url: {orig_embed_path}")
         else:

--- a/updatePageLinks.py
+++ b/updatePageLinks.py
@@ -32,7 +32,7 @@ for filename in os.listdir(target_folder):
 
 for filename in my_rst_files:
     path_and_name = os.path.join(target_folder, filename)
-    with open(path_and_name) as file:
+    with open(path_and_name, encoding='utf-8') as file:
         while line := file.readline():
             if ":confluencePageId:" in line:
                 my_rsts_pageid = line.split(":confluencePageId: ")[1][:-1]
@@ -41,7 +41,7 @@ for filename in my_rst_files:
                 break
 
     # write the file out
-    with open(rst_pageids_filename, 'w') as file:
+    with open(rst_pageids_filename, 'w', encoding='utf-8') as file:
         for k,v in rst_pageids.items():
             file.write(f"{k}:{v}\n")
 
@@ -70,9 +70,9 @@ for filename in my_rst_files:
         out_filename = filename
     out_path_and_name = os.path.join(target_folder, out_filename)
     # open input file
-    with open(path_and_name, 'r') as sfile:     # sfile = source file
+    with open(path_and_name, 'r', encoding='utf-8') as sfile:     # sfile = source file
         all_sfile_lines = sfile.readlines()
-    with open(out_path_and_name, 'w') as tfile:     # tfile = target file
+    with open(out_path_and_name, 'w', encoding='utf-8') as tfile:     # tfile = target file
         for n,line in enumerate(all_sfile_lines):
             if ("<https://optile.atlassian.net/wiki/spaces/" in line or "</wiki/spaces/" in line) and "/pages/" in line and not line.startswith("Original URL:"):
                 for find_match in re.findall(r'<?(https:\/\/\w+.*spaces\/\w+\/pages\/(\d+)?.*)>?|<(\/wiki\/spaces\/\w+\/pages\/(\d+)\/?.*)>',line):      # if there are >1 links in a line
@@ -99,7 +99,7 @@ for filename in my_rst_files:
 #    with open(path_and_name, 'w') as file:
 #        file.writelines(all_file_lines)
     # write the file out
-    with open(conf_pageids_filename, 'w') as file:
+    with open(conf_pageids_filename, 'w', encoding='utf-8') as file:
         for n in conf_pageids:
             file.write(str(n) + '\n')
 


### PR DESCRIPTION
Couple of fixes and minor improvements:
- Sphinx could not be turned off since it defaulted to true and only stored true in the arg, I have turned it off by default.
- Added `--no-rst` to disable the rst file export.
- Fixed some arguments in the `dump_html` calls that were missing.
- Use `shutil` to copy since `cp` does not exist on Windows.
- Removing "illegal" characters from file-names, this very much depends on the OS though but I had a few exceptions pop up because of this on my machine.
- Added try-catch to downloads, some failed in my environment due to invalid links.
- Do not override attachments, this speeds things up a bit when debugging.
- Fixed encoding issues, now writing everything as utf-8.